### PR TITLE
Don't use smtpClient.SendAsync in your current setup

### DIFF
--- a/src/Buzz.Hybrid/Net/SmtpMailer.cs
+++ b/src/Buzz.Hybrid/Net/SmtpMailer.cs
@@ -107,13 +107,7 @@
                     Credentials = credentials ?? CredentialCache.DefaultNetworkCredentials
                 };
 
-                smtpClient.SendCompleted += (sender, args) =>
-                {
-                    smtpClient.Dispose();
-                    msg.Dispose();
-                };
-
-                smtpClient.SendAsync(msg, null);
+                smtpClient.Send(msg, null);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
If you are using SendAsync, you should check whether you can already send the next e-mail 
As stated in the SendAsync documentation (http://msdn.microsoft.com/en-us/library/x5x13z6h%28v=vs.110%29.aspx): "After calling SendAsync, you must wait for the e-mail transmission to complete before attempting to send another e-mail message using Send or SendAsync."   You are not checking whether the transmission has ended or not.

Furthermore, if you using async, it's the callback who will tell you if the message has been send sucessuflly.  You are now returning "true" if the messages has been passed on a new thread.  You will (almost always) return true in your code.  Check also the example on the same url (http://msdn.microsoft.com/en-us/library/x5x13z6h%28v=vs.110%29.aspx).

IMHO (and experience) the default SMTP client is not very good when building async or parallel smtp sending of e-mails.